### PR TITLE
fix: inherit from stream and fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-declare module 'bunyan-gelf' {
-    import Stream from 'stream';
-    
-    export default Stream;
+declare module "bunyan-gelf" {
+  import { Writable } from "stream";
+
+  export default class BunyanToGelfStream extends Writable {
+    constructor(opts) {}
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-const Tcp = require('./transports/Tcp');
-const Udp = require('./transports/Udp');
+const { Writable } = require("node:stream");
+
+const Tcp = require("./transports/Tcp");
+const Udp = require("./transports/Udp");
 
 const LEVELS = {
   EMERGENCY: 0,
@@ -12,7 +14,7 @@ const LEVELS = {
   DEBUG: 7,
 };
 
-class BunyanToGelfStream {
+class BunyanToGelfStream extends Writable {
   /**
    * BunyanToGelfStream
    *
@@ -22,7 +24,9 @@ class BunyanToGelfStream {
    * @param options.protocol Protocol can be 'udp' or 'tcp'
    */
   constructor(options = {}) {
-    this._transport = options.protocol === 'tcp' ? new Tcp(options) : new Udp(options);
+    super();
+    this._transport =
+      options.protocol === "tcp" ? new Tcp(options) : new Udp(options);
   }
 
   /**
@@ -79,4 +83,3 @@ class BunyanToGelfStream {
 }
 
 module.exports = BunyanToGelfStream;
-


### PR DESCRIPTION
bunyan specifies the stream in addStream as a NodeJS writable
stream. some tools using bunyan explicitly test for this, e.g.
renovate-bot by checking the `stream.writable` property.

this fix makes the class a real writeable strem and also fixes
the typescript definitions which were not fitting.