### PR TITLE
fix: parse string to json

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ class BunyanToGelfStream {
    * @param log
    */
   write(log) {
+    if (typeof log === 'string') {
+      log = JSON.parse(log);
+    }
+
     const message = {
       host: log.hostname,
       timestamp: +new Date(log.time) / 1000,


### PR DESCRIPTION
this guards against json passed as string that is used in some
implementations